### PR TITLE
[REFACTOR] Use signed distance function to calculate circle picking surface

### DIFF
--- a/src/graph/nodes/circle/Circle.picking.fs.glsl
+++ b/src/graph/nodes/circle/Circle.picking.fs.glsl
@@ -1,6 +1,8 @@
 #version 300 es
 precision highp float;
 
+#pragma glslify: import(../shaders/shapes.glsl)
+
 flat in vec4 fColor;
 flat in float fPixelLength;
 in vec2 vFromCenter;
@@ -8,8 +10,8 @@ in vec2 vFromCenter;
 out vec4 fragColor;
 
 void main() {
-    float fromCenter = length(vFromCenter);
-    if (fromCenter > 1.0) {
+    float sd = sdCircle(vFromCenter, 1.0);
+    if (sd > 0.0) {
         discard;
     }
     fragColor = fColor;


### PR DESCRIPTION
### Description
Refactor circle picking fragment shader to use signed distance function of a circle to calculate the distance the mouse is from the circle's surface.

### Considerations
Here we refactor to use the signed distance function to mimic the picking fragment shaders of other shapes. 