### PR TITLE
[FEATURE] Add world point to pixel coordinate utility

### DIFF
--- a/examples/src/UX/overlay.ts
+++ b/examples/src/UX/overlay.ts
@@ -1,37 +1,15 @@
 import {html, render} from 'lit-html';
-import { mat4, vec4, vec2 } from 'gl-matrix';
 import {GraferController, UX} from '../../../src/mod';
 
 const WINDOW_DEVICE_PIXEL_RATIO = window.devicePixelRatio;
-enum PixelPointXPosition {
-    'CENTER' = 0,
-    'LEFT' = -1,
-    'RIGHT' = 1,
-}
-enum PixelPointYPosition {
-    'CENTER' = 0,
-    'TOP' = 1,
-    'BOTTOM' = -1,
-}
-function worldToPixel(controller, position, pxptXPos = PixelPointXPosition.CENTER, pxptYPos = PixelPointYPosition.CENTER): vec2 {
-    const { camera } = controller.viewport; // prefer-destructing is a dumb eslint rule...
-    const renderMatrix = mat4.mul(mat4.create(), camera.projectionMatrix, camera.viewMatrix);
-    mat4.mul(renderMatrix, renderMatrix, controller.viewport.graph.matrix);
-
-    const projected = vec4.set(vec4.create(), position[0] + pxptXPos*position[3], position[1] + pxptYPos*position[3], position[2], 1);
-    vec4.transformMat4(projected, projected, renderMatrix);
-
-    const { size } = controller.viewport; // prefer-destructing is a dumb eslint rule...
-    const x = (projected[0] / projected[3]) * size[0] * 0.5 + size[0] * 0.5;
-    const y = (projected[1] / projected[3]) * size[1] * 0.5 + size[1] * 0.5;
-
-    return vec2.set(vec2.create(), x, y);
-}
 
 const onHoverOnEventFactory = (controller, tooltipCtx) => {
     return (event, detail): void => {
         const point = controller.viewport.graph.getPointByID(detail.id);
-        const pxPoint = worldToPixel(controller, point, PixelPointXPosition.CENTER, PixelPointYPosition.CENTER);
+        const pxPoint = UX.coordinate.Coordinate.worldPointToRelativePixelCoordinate(controller, point, {
+            x: UX.coordinate.PixelCoordXPosition.CENTER,
+            y: UX.coordinate.PixelCoordYPosition.CENTER,
+        });
 
         const graphBB = controller.viewport.canvas.getBoundingClientRect();
         const tooltipBB = tooltipCtx.canvas.getBoundingClientRect();

--- a/examples/src/UX/tooltips.ts
+++ b/examples/src/UX/tooltips.ts
@@ -1,37 +1,15 @@
 import {html, render} from 'lit-html';
-import { mat4, vec4, vec2 } from 'gl-matrix';
 import {GraferController, UX} from '../../../src/mod';
 
 const WINDOW_DEVICE_PIXEL_RATIO = window.devicePixelRatio;
-enum PixelPointXPosition {
-    'CENTER' = 0,
-    'LEFT' = -1,
-    'RIGHT' = 1,
-}
-enum PixelPointYPosition {
-    'CENTER' = 0,
-    'TOP' = 1,
-    'BOTTOM' = -1,
-}
-function worldToPixel(controller, position, pxptXPos = PixelPointXPosition.CENTER, pxptYPos = PixelPointYPosition.CENTER): vec2 {
-    const { camera } = controller.viewport; // prefer-destructing is a dumb eslint rule...
-    const renderMatrix = mat4.mul(mat4.create(), camera.projectionMatrix, camera.viewMatrix);
-    mat4.mul(renderMatrix, renderMatrix, controller.viewport.graph.matrix);
-
-    const projected = vec4.set(vec4.create(), position[0] + pxptXPos*position[3], position[1] + pxptYPos*position[3], position[2], 1);
-    vec4.transformMat4(projected, projected, renderMatrix);
-
-    const { size } = controller.viewport; // prefer-destructing is a dumb eslint rule...
-    const x = (projected[0] / projected[3]) * size[0] * 0.5 + size[0] * 0.5;
-    const y = (projected[1] / projected[3]) * size[1] * 0.5 + size[1] * 0.5;
-
-    return vec2.set(vec2.create(), x, y);
-}
 
 const onHoverOnEventFactory = (controller) => {
     return (event, detail): void => {
         const point = controller.viewport.graph.getPointByID(detail.id);
-        const pxPoint = worldToPixel(controller, point, PixelPointXPosition.RIGHT, PixelPointYPosition.TOP);
+        const pxPoint = UX.coordinate.Coordinate.worldPointToRelativePixelCoordinate(controller, point, {
+            x: UX.coordinate.PixelCoordXPosition.RIGHT,
+            y: UX.coordinate.PixelCoordYPosition.TOP,
+        });
 
         const tooltipEl = document.querySelector('.tooltiptext') as HTMLElement;
         tooltipEl.style.left = `${pxPoint[0]/WINDOW_DEVICE_PIXEL_RATIO}px`;

--- a/src/UX/coordinate/Coordinate.ts
+++ b/src/UX/coordinate/Coordinate.ts
@@ -1,0 +1,45 @@
+import { mat4, vec4, vec2 } from 'gl-matrix';
+import { GraferController } from 'src/mod';
+
+export enum PixelCoordXPosition {
+    'CENTER' = 0,
+    'LEFT' = -1,
+    'RIGHT' = 1,
+}
+export enum PixelCoordYPosition {
+    'CENTER' = 0,
+    'TOP' = 1,
+    'BOTTOM' = -1,
+}
+export interface PixelCoordPosition {
+    x: PixelCoordXPosition,
+    y: PixelCoordYPosition,
+}
+const kDefaultPixelCoordPosition: PixelCoordPosition = {
+    x: PixelCoordXPosition.CENTER,
+    y: PixelCoordYPosition.CENTER,
+};
+
+export class Coordinate {
+    public static worldPointToRelativePixelCoordinate(controller: GraferController, point: vec4, position?: PixelCoordPosition): vec2 {
+        position = Object.assign({}, kDefaultPixelCoordPosition, position);
+        const camera = controller.viewport.camera;
+        const renderMatrix = mat4.mul(mat4.create(), camera.projectionMatrix, camera.viewMatrix);
+        mat4.mul(renderMatrix, renderMatrix, controller.viewport.graph.matrix);
+
+        const projected = vec4.set(
+            vec4.create(),
+            point[0] + position.x*point[3],
+            point[1] + position.y*point[3],
+            point[2],
+            1
+        );
+        vec4.transformMat4(projected, projected, renderMatrix);
+
+        const size = controller.viewport.size;
+        const x = (projected[0] / projected[3]) * size[0] * 0.5 + size[0] * 0.5;
+        const y = (projected[1] / projected[3]) * size[1] * 0.5 + size[1] * 0.5;
+
+        return vec2.set(vec2.create(), x, y);
+    }
+}

--- a/src/UX/coordinate/mod.ts
+++ b/src/UX/coordinate/mod.ts
@@ -1,0 +1,1 @@
+export * from './Coordinate';

--- a/src/UX/mod.ts
+++ b/src/UX/mod.ts
@@ -1,4 +1,5 @@
 export * as mouse from './mouse/mod';
 export * as picking from './picking/mod';
 export * as animation from './animation/mod';
+export * as coordinate from './coordinate/mod';
 export * from './debug/DebugMenu';


### PR DESCRIPTION
### Changes
- Add coordinate module that provides users with static utility methods for conversions between world and pixel space.
- Add static utility to convert between world to relative pixel space.
- Refactor examples to utilize newly added coordinate module and demonstrate simplified user workflows.

### Thoughts
- Coordinate utilities feel disconnected from main library; it seems inconvenient for the user to have to pass in the Grafer controller into the utilities. Consider moving this code to be integrated within a controller instance.
- This PR adds a way to go from world to pixel space. I'd be curious to see if there is interest in going the opposite direction from pixel to world space within the graph. 