### PR TITLE
feat: expose adding a layer at a specific index

### DIFF
--- a/docs/api/grafer-controller.md
+++ b/docs/api/grafer-controller.md
@@ -72,6 +72,16 @@ Initiates a graph render using the [viewport method](./viewport.md#render).
 |  name  | string | A string serving as an identifier for the layer to be added. Should be unique. |
 |  useColors  | boolean - *optional* | A boolean indicating if the nodes, edges, and labels in the layer should use colors stored in the grafer controller during rendering, otherwise use colors specified in the layer data. |
 
+### `addLayerAt`
+###### void
+
+| Parameter  | Type | Description |
+| :--- | :--- | :--- |
+|  layerData  | GraferLayerData | An object containing lists of nodes, edges, and labels. See [GraferLayerData](./grafer-layer-data.md) for more information. |
+|  name  | string | A string serving as an identifier for the layer to be added. Should be unique. |
+|  useColors  | boolean - *optional* | A boolean indicating if the nodes, edges, and labels in the layer should use colors stored in the grafer controller during rendering, otherwise use colors specified in the layer data. |
+| index | number - *optional* | A numeric value indicating at which position in the layer list should this layer be inserted into. If the index is out of range (i.e. layer.length < index < 0)  then it will simply append it to the end as would calling [addLayer](#addlayer). |
+
 ### `removeLayerByName`
 ###### void
 

--- a/src/grafer/GraferController.ts
+++ b/src/grafer/GraferController.ts
@@ -204,7 +204,7 @@ export class GraferController extends EventEmitter {
         }
     }
 
-    public addLayer(layerData: GraferLayerData, name: string, useColors?: boolean): void {
+    public addLayerAt(layerData: GraferLayerData, name: string, enablePicking: boolean = true, useColors?: boolean, index?: number): void {
         if( useColors && !this.hasColors ) {
             throw new Error('No colors found.');
         }
@@ -225,10 +225,27 @@ export class GraferController extends EventEmitter {
         const labelsData = layerData.labels;
         const labels = this.addLabels(labelsData, useColors);
 
+        // make sure to set a default layer name if not provided
+        const layerName = name || `Layer_${index || graph.layers.length}`;
+        // check if name already taken, otherwise it will silent replace
+        // existing layer which is a hidden side effect
+        if(graph.layers.filter(l => l.name === layerName).length > 0) {
+            throw new Error('A layer of this name already exists, remove existing layer first or change the name of this one!');
+        }
+
         if (nodes || edges || labels) {
-            const layer = new Layer(nodes, edges, labels, name);
-            graph.layers.push(layer);
-            layer.on(EventEmitter.omniEvent, (...args) => this.emit(...args));
+            const layer = new Layer(nodes, edges, labels, layerName);
+
+            if (index >= 0 && index <= graph.layers.length) {
+                graph.addLayerAt(layer, index);
+            } else {
+                graph.addLayer(layer);
+            }
+
+            // selectively disabling this on a per layer basis does not seem to work
+            // if (enablePicking) {
+                layer.on(EventEmitter.omniEvent, (...args) => this.emit(...args));
+            // }
 
             if ('options' in layerData) {
                 const options = layerData.options;
@@ -240,6 +257,10 @@ export class GraferController extends EventEmitter {
                 }
             }
         }
+    }
+
+    public addLayer(layerData: GraferLayerData, name: string, enablePicking: boolean = true, useColors?: boolean): void {
+        this.addLayerAt(layerData, name, enablePicking, useColors);
     }
 
     public removeLayerByName(name: string): void {

--- a/src/grafer/GraferController.ts
+++ b/src/grafer/GraferController.ts
@@ -204,7 +204,7 @@ export class GraferController extends EventEmitter {
         }
     }
 
-    public addLayerAt(layerData: GraferLayerData, name: string, enablePicking: boolean = true, useColors?: boolean, index?: number): void {
+    public addLayerAt(layerData: GraferLayerData, name: string, useColors?: boolean, index?: number): void {
         if( useColors && !this.hasColors ) {
             throw new Error('No colors found.');
         }
@@ -259,8 +259,8 @@ export class GraferController extends EventEmitter {
         }
     }
 
-    public addLayer(layerData: GraferLayerData, name: string, enablePicking: boolean = true, useColors?: boolean): void {
-        this.addLayerAt(layerData, name, enablePicking, useColors);
+    public addLayer(layerData: GraferLayerData, name: string, useColors?: boolean): void {
+        this.addLayerAt(layerData, name, useColors);
     }
 
     public removeLayerByName(name: string): void {


### PR DESCRIPTION
Exposing the `addLayerAt` functionality in the graph controller.
Existing function simply calls the new one with no index specified, this should keep things backwards compatible.
