### PR TITLE
fix: handle mouse events on left side of canvas when margin present

### DIFF
--- a/src/UX/mouse/MouseHandler.ts
+++ b/src/UX/mouse/MouseHandler.ts
@@ -283,7 +283,7 @@ export class MouseHandler extends EventEmitter.mixin(UXModule) {
         }
 
         this.newState.valid = Boolean(
-            canvas[0] >= rect.left && canvas[0] <= rect.right &&
+            canvas[0] >= 0 && canvas[0] <= rect.right &&
             canvas[1] >= 0 && canvas[1] <= rect.height
         );
 

--- a/src/UX/mouse/MouseHandler.ts
+++ b/src/UX/mouse/MouseHandler.ts
@@ -283,7 +283,7 @@ export class MouseHandler extends EventEmitter.mixin(UXModule) {
         }
 
         this.newState.valid = Boolean(
-            canvas[0] >= 0 && canvas[0] <= rect.right &&
+            canvas[0] >= 0 && canvas[0] <= rect.width &&
             canvas[1] >= 0 && canvas[1] <= rect.height
         );
 


### PR DESCRIPTION
There was a bug where, when a parent element of the canvas had a left margin, mouse events within the inner left portion of the canvas proportional to that margin would be invalidated. This change fixes that issue
