### PR TITLE
feat: add hasPoint function to GraphPoints

### DIFF
--- a/src/data/GraphPoints.ts
+++ b/src/data/GraphPoints.ts
@@ -120,6 +120,10 @@ export class GraphPoints extends DataTexture {
         ];
     }
 
+    public hasPoint(id: number | string): boolean {
+        return this.map.has(id);
+    }
+
     public getPointByID(id: number | string): [number, number, number, number] {
         return this.getPointByIndex(this.getPointIndex(id));
     }


### PR DESCRIPTION
This PR adds a utility function to check if GraphPoints has a point with a particular ID. This is useful for tracking the existence of particular points to know whether we need to call `setPointByID` or `addPoints`.